### PR TITLE
Use packaging.version.Version for major_minor

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -1,8 +1,16 @@
 # History
 
-## 0.0.6 (2021-06-16)
+## 0.0.8 (2021-06-16)
 
 * Add support for pre-release packages that don't use a dot to separate the pre-release signifier.
+
+## 0.0.7 (2021-11-03)
+
+* Show default argument values in the help.
+
+## 0.0.6 (2021-11-03)
+
+* Support a few more time formats
 
 ## 0.0.5 (2020-10-13)
 

--- a/HISTORY.md
+++ b/HISTORY.md
@@ -1,6 +1,6 @@
 # History
 
-## Unreleased
+## 0.0.6 (2021-06-16)
 
 * Add support for pre-release packages that don't use a dot to separate the pre-release signifier.
 

--- a/HISTORY.md
+++ b/HISTORY.md
@@ -1,5 +1,9 @@
 # History
 
+## Unreleased
+
+* Add support for pre-release packages that don't use a dot to separate the pre-release signifier.
+
 ## 0.0.5 (2020-10-13)
 
 * Use pretty table for better formatting.

--- a/nep29/nep29.py
+++ b/nep29/nep29.py
@@ -18,14 +18,13 @@ Copyright Mark Harfouche 2019
 from datetime import datetime, timedelta
 from prettytable import PrettyTable, MARKDOWN
 import requests
-from distutils.version import LooseVersion
 from packaging.version import Version
 
 
 def major_minor_version(version):
     """Given a version string, returns the major and minor version a tuple"""
-    version = Version(version)
-    return version.major, version.minor
+    # version = Version(version)
+    return version.epoch, version.major, version.minor
 
 
 def keep_oldest_minor_only(version_dates):
@@ -47,10 +46,13 @@ def get_versions_dates(package_name, skip_rc=True):
     release_dates = []
     for k, v in response['releases'].items():
         # print(k)
+        # NOTE: for a version that doesn't comply to PEP 440, this will
+        # raise packaging.version.InvalidVersion:
+        version = Version(k)
         for item in v:
             # print(item['packagetype'])
             if item['packagetype'] == 'sdist':
-                if skip_rc and 'rc' in k:
+                if skip_rc and version.is_prerelease:
                     continue
                 upload_time = item['upload_time_iso_8601']
                 for format in ['%Y-%m-%dT%H:%M:%S.%fZ',
@@ -65,7 +67,7 @@ def get_versions_dates(package_name, skip_rc=True):
                         f"Could not convert {upload_time} into a standard "
                         "datetime object")
 
-                release_dates.append((k, date))
+                release_dates.append((version, date))
 
     release_dates.sort(key=lambda x: x[1], reverse=True)
     return release_dates
@@ -129,7 +131,7 @@ def nep29_versions(package_name, *,
                       for vd, good in zip(version_dates, good_indicator)
                       if good]
 
-    valid_releases.sort(key=lambda x: LooseVersion(x[0]), reverse=True)
+    valid_releases.sort(reverse=True)
     return valid_releases
 
 

--- a/nep29/nep29.py
+++ b/nep29/nep29.py
@@ -22,9 +22,11 @@ from packaging.version import Version
 
 
 def major_minor_version(version):
-    """Given a version string, returns the major and minor version a tuple"""
-    # version = Version(version)
-    return version.epoch, version.major, version.minor
+    """Given a version, returns the tuple epoch, major, minor"""
+    # version.release works in either packaging 19 or 20
+    # as of packaging 20+, can use version.major, version.minor instead
+    major, minor = version.release[:2]
+    return version.epoch, major, minor
 
 
 def keep_oldest_minor_only(version_dates):
@@ -52,8 +54,11 @@ def get_versions_dates(package_name, skip_rc=True):
         for item in v:
             # print(item['packagetype'])
             if item['packagetype'] == 'sdist':
-                if skip_rc and version.is_prerelease:
-                    continue
+                if version.is_prerelease:
+                    if skip_rc or not version.pre[0] == 'rc':
+                        continue
+                # if skip_rc and version.is_prerelease:
+                    # continue
                 upload_time = item['upload_time_iso_8601']
                 for format in ['%Y-%m-%dT%H:%M:%S.%fZ',
                                '%Y-%m-%dT%H:%M:%SZ']:

--- a/nep29/nep29.py
+++ b/nep29/nep29.py
@@ -19,12 +19,13 @@ from datetime import datetime, timedelta
 from prettytable import PrettyTable, MARKDOWN
 import requests
 from distutils.version import LooseVersion
+from packaging.version import Version
 
 
 def major_minor_version(version):
     """Given a version string, returns the major and minor version a tuple"""
-    split = version.split('.')
-    return int(split[0]), int(split[1])
+    version = Version(version)
+    return version.major, version.minor
 
 
 def keep_oldest_minor_only(version_dates):

--- a/nep29/nep29.py
+++ b/nep29/nep29.py
@@ -56,7 +56,9 @@ def get_versions_dates(package_name, skip_rc=True):
             if item['packagetype'] == 'sdist':
                 if version.is_prerelease:
                     if skip_rc or not version.pre[0] == 'rc':
+                        # skip unless we do not skip RCs and this is RC
                         continue
+                # alt: interpret skip_rc as allow any prerelease (e.g, betas)
                 # if skip_rc and version.is_prerelease:
                     # continue
                 upload_time = item['upload_time_iso_8601']
@@ -118,7 +120,7 @@ def nep29_versions(package_name, *,
                    skip_rc=True,
                    release_date=None,
                    consider_first_minor_only=True):
-    version_dates = get_versions_dates(package_name, skip_rc=True)
+    version_dates = get_versions_dates(package_name, skip_rc=skip_rc)
     if consider_first_minor_only:
         version_dates = keep_oldest_minor_only(version_dates)
     good_nep29_date_indicator = good_nep29_date(version_dates,

--- a/nep29/tests/test_nep29.py
+++ b/nep29/tests/test_nep29.py
@@ -1,6 +1,13 @@
 import nep29
+from nep29 import nep29_versions
 import pytest
 
 
 def test_project_import():
     pass
+
+def test_pandas():
+    # Pre-release information can be included as letters
+    # not seperated by a '.' from the version number
+    # the pandas package uses this notation.
+    nep29_versions('pandas')

--- a/nep29/tests/test_nep29.py
+++ b/nep29/tests/test_nep29.py
@@ -6,6 +6,16 @@ import pytest
 def test_project_import():
     pass
 
+@pytest.mark.parametrize('vstring,expected', [
+    ("1!2.3.4", (1, 2, 3)),
+    ("1.2.3", (0, 1, 2)),
+])
+def test_major_minor_version(vstring, expected):
+    from packaging.version import Version
+    v = Version(vstring)
+    assert nep29.nep29.major_minor_version(v) == expected
+
+
 def test_pandas():
     # Pre-release information can be included as letters
     # not seperated by a '.' from the version number

--- a/nep29/tests/test_nep29.py
+++ b/nep29/tests/test_nep29.py
@@ -1,10 +1,14 @@
 import nep29
 from nep29 import nep29_versions
 import pytest
+from unittest.mock import patch, Mock
+from datetime import datetime
+from packaging.version import Version
 
 
 def test_project_import():
     pass
+
 
 @pytest.mark.parametrize('vstring,expected', [
     ("1!2.3.4", (1, 2, 3)),
@@ -14,6 +18,77 @@ def test_major_minor_version(vstring, expected):
     from packaging.version import Version
     v = Version(vstring)
     assert nep29.nep29.major_minor_version(v) == expected
+
+
+def _mock_release_info(release_info):
+    # returns a mock for the requests.Response object
+    def _make_release_entry(version, date, packagetype='sdist'):
+        return version, [{
+            'packagetype': packagetype,
+            'upload_time_iso_8601': date + 'T00:00:00.000000Z'
+        }]
+
+    package = {'releases': dict(_make_release_entry(*info)
+                                for info in release_info)}
+    request = Mock()
+    request.json = Mock(return_value=package)
+    return request
+
+
+@patch.object(nep29.nep29, 'datetime', Mock(wraps=datetime))
+def _nep29_versions_test(request_mock, expected, *args, **kwargs):
+    # core code to run tests of nep29_versions from a mock for the
+    # requests.Response object as a list of expected version strings;
+    # additional args/kwargs passed to nep29_versions
+    nep29.nep29.datetime.utcnow.return_value = datetime(2021, 1, 1)
+    with patch('nep29.nep29.requests.get', Mock(return_value=request_mock)):
+        results = nep29_versions('foo', *args, **kwargs)
+
+    found_versions = set(r[0] for r in results)
+    assert found_versions == set(Version(v) for v in expected)
+
+
+@pytest.mark.parametrize('releases,expected', [
+    #NOTE: for these tests we patch so that today is 2021-01-01, midnight.
+    # All mock releases are at midnight GMT.
+    (
+        # default: include up to 3 minor versions if released long ago
+        _mock_release_info([('2.0.0', '2015-01-01'),
+                            ('1.2.0', '2014-01-01'),
+                            ('1.1.0', '2013-01-01'),
+                            ('1.0.0', '2012-01-01')]),
+        ['2.0.0', '1.2.0', '1.1.0']
+    ),
+    (
+        # default: include all minor versions first released in 24 months
+        _mock_release_info([('1.9.0', '2020-12-01'),
+                            ('1.8.0', '2020-09-01'),
+                            ('1.7.0', '2020-06-01'),
+                            ('1.6.0', '2020-01-01'),
+                            ('1.5.0', '2019-06-01'),
+                            ('1.4.0', '2018-12-01')]),
+        ['1.9.0', '1.8.0', '1.7.0', '1.6.0', '1.5.0']
+    ),
+    (
+        # default: release candidates should not be included
+        _mock_release_info([('2.0.0.rc0', '2020-12-01'),
+                            ('1.3.0', '2020-11-01'),
+                            ('1.2.0', '2020-10-01'),
+                            ('1.1.0', '2020-09-01')]),
+        ['1.3.0', '1.2.0', '1.1.0']
+    ),
+])
+def test_nep29_versions(releases, expected):
+    _nep29_versions_test(releases, expected)
+
+
+def test_nep29_versions_allow_rc():
+    releases = _mock_release_info([('2.0.0.rc0', '2020-12-01'),
+                                   ('1.3.0', '2020-11-01'),
+                                   ('1.2.0', '2020-10-01'),
+                                   ('1.1.0', '2020-09-01')])
+    expected = ['2.0.0.rc0', '1.3.0', '1.2.0', '1.1.0']
+    _nep29_versions_test(releases, expected, skip_rc=False)
 
 
 def test_pandas():

--- a/setup.py
+++ b/setup.py
@@ -9,7 +9,7 @@ with open('README.md') as readme_file:
 with open('HISTORY.md') as history_file:
     history = history_file.read()
 
-requirements = ['requests', 'prettytable', ]
+requirements = ['requests', 'prettytable', 'packaging', ]
 
 test_requirements = ['pytest', ]
 


### PR DESCRIPTION
The current implementation of `major_minor_versions` assumes that the first two segments of all versions (when split by '.')  are purely numeric. This is not required by PEP 440. [Pre-releases can be of the format X.YbN](https://www.python.org/dev/peps/pep-0440/#pre-releases). I specifically found this due to [pandas 0.2b1](https://pypi.org/project/pandas/0.2b1/), which raised `ValueError: invalid literal for int() with base 10: '2b1'`.

This PR fixes it by using `packaging.version.Version` to parse the version string in `major_minor_versions`. Downside is that it adds the requirement of `packaging`.