### PR TITLE
[WIP] Add support for Python versions

### DIFF
--- a/nep29/nep29.py
+++ b/nep29/nep29.py
@@ -21,6 +21,24 @@ import requests
 from packaging.version import Version
 
 
+def get_python_versions_dates():
+    # Python releases for 3.X.0 are hard-coded since they can't be obtained
+    # from PyPI (only concerned with X>=5)
+    format = "%Y-%m-%d"
+    python_releases = {
+        '3.5.0': '2015-09-13',
+        '3.6.0': '2016-12-23',
+        '3.7.0': '2018-06-27',
+        '3.8.0': '2019-10-14',
+        '3.9.0': '2020-10-05',
+        '3.10.0': '2020-10-04',
+    }
+    release_dates = [(Version(v), datetime.strptime(d, format))
+                     for v, d in python_releases.items()]
+    release_dates.sort(key=lambda x: x[1], reverse=True)
+    return release_dates
+
+
 def major_minor_version(version):
     """Given a version, returns the tuple epoch, major, minor"""
     # version.release works in either packaging 19 or 20
@@ -43,6 +61,9 @@ def keep_oldest_minor_only(version_dates):
 
 
 def get_versions_dates(package_name, skip_rc=True):
+    if package_name == 'python':
+        return get_python_versions_dates()
+
     r = requests.get(f"https://pypi.org/pypi/{package_name}/json")
     response = r.json()
     release_dates = []


### PR DESCRIPTION
I realized it would be nice to be able to use `nep29` for Python itself as well. (I was just thinking, "hey, can't I drop Python 3.7 now?" and wondered if `nep29` could give me the answer.)

I've started on implementing that in a way that requires hard-coding each Python 3.X.0 release date (not aware of a better way.) Before I go any further, take a look and let me know what you think.

Major issue I see -- the official NEP29 docs have different rules for Python than NumPy. There's currently no way to distinguish input from default arguments vs. explicitly requesting `--n_months 24`, while the default for Python should be `--n_months 42`. The best thing I can think for that would be if, in the case that users give default arguments `--n_months 24 --n_minor 3`, we could issue a warning that Python should be `--n_months 42`. The warning would be issued whether the arguments were set by default or explicitly given. This also doesn't include RCs, so the `skip_rc` flag doesn't do anything (and should probably issue a warning to say that).

Anyway, this concern might be a complete blocker on this idea, which is why I wanted feedback before taking this any further. Thoughts?